### PR TITLE
Refactor AI service constructors to support configurable base URLs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,24 @@
+## 1.0.7
+
+**Released on:** 2026-01-26
+
+**Compatibility note:** This version is compatible **from Moodle 4.5 to Moodle 5.1**.
+
+## Added
+- **Configurable base URLs for DataCurso AI services**  
+  Added support for configurable base URLs for both the **standard** and **EU-hosted** DataCurso AI services, allowing greater flexibility across environments.
+- **Optional base URL parameters in constructors**  
+  Updated service constructors to accept optional base URL parameters, enabling explicit overrides when needed.
+
+## Changed
+- **Centralized base URL resolution via instance method**  
+  Refactored base URL access to ensure the correct instance method is used when resolving the active base URL, improving consistency and maintainability.
+- **Service initialization flow updated**  
+  Adjusted internal initialization logic so all API requests correctly respect the configured base URL (standard or EU-hosted).
+- **Version bump**  
+  Release version bumped to **1.0.7**.
+
+
 ## 1.0.6
 
 **Released on:** 2026-01-19

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,57 @@
+## 1.0.6
+
+**Released on:** 2026-01-19
+
+## Added
+
+- **Enhanced webservice setup error logging.**  
+Improved error reporting during webservice registration by including the original exception message, providing clearer diagnostics when the setup process fails.
+
+## Changed
+
+- **Improved boolean evaluation logic.**  
+Adjusted the `is_for_ue` method to ensure proper and safe boolean comparison, preventing unintended conditional behavior.
+
+## Fixed
+
+- **Webservice setup debugging limitations.**  
+Resolved an issue where webservice registration failures did not expose sufficient context, making troubleshooting difficult.
+
+## Changed
+
+- **Release bump to 1.0.6**  
+Updated the plugin version and release metadata to **1.0.6** to reflect the included improvements and fixes.
+
+## 1.0.5
+
+**Released on:** 2025-12-04
+
+ **Compatibility note:** This version is compatible **only with Moodle 4.5**.
+
+## Fixed
+- **Upgrade savepoint order corrected**  
+  Reordered the upgrade savepoint to prevent upgrade failures related to the `aiprovider_datacurso_userlimit`
+
+## 1.0.4
+
+**Released on:** 2025-12-02
+
+Fixed
+- add missing capabilities and web service functions
+
+## 1.0.3
+
+**Released on:** 2025-12-02
+
+ **Compatibility note:** This version is compatible **only with Moodle 4.5**.
+
+## Added
+- **Automated release workflow for the plugin.**  
+  A new GitHub Actions workflow was added to streamline/automate Moodle plugin releases.
+- **Support only for Moodle 4.5.**  
+  Added `$plugin->supported` in `version.php` to declare Moodle 4.5 as the only supported version.
+
+## Changed
+- **Release bump to 1.0.3**  
+  The plugin release number was updated to **1.0.3**.
+

--- a/classes/form/user_token_limit_form.php
+++ b/classes/form/user_token_limit_form.php
@@ -45,7 +45,12 @@ class user_token_limit_form extends dynamic_form {
 
         if ($editing) {
             $userlabel = (string)$this->optional_param('userlabel', '', PARAM_TEXT);
-            $mform->addElement('static', 'userlabel', get_string('usertokenlimit_user', 'aiprovider_datacurso'), format_string($userlabel));
+            $mform->addElement(
+                'static',
+                'userlabel',
+                get_string('usertokenlimit_user', 'aiprovider_datacurso'),
+                format_string($userlabel)
+            );
             $mform->addHelpButton('userlabel', 'usertokenlimit_user_readonly', 'aiprovider_datacurso');
             $mform->addElement('hidden', 'userid');
             $mform->setType('userid', PARAM_INT);

--- a/classes/httpclient/ai_course_api.php
+++ b/classes/httpclient/ai_course_api.php
@@ -26,7 +26,6 @@ namespace aiprovider_datacurso\httpclient;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class ai_course_api extends datacurso_api_base {
-
     /** Default base URL for the standard DataCurso course AI service. */
     private const DEFAULT_BASE_URL = 'https://course-ai.datacurso.com';
 

--- a/classes/httpclient/ai_course_api.php
+++ b/classes/httpclient/ai_course_api.php
@@ -26,17 +26,28 @@ namespace aiprovider_datacurso\httpclient;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class ai_course_api extends datacurso_api_base {
+
+    /** Default base URL for the standard DataCurso course AI service. */
+    private const DEFAULT_BASE_URL = 'https://course-ai.datacurso.com';
+
+    /** Default base URL for the EU-hosted DataCurso course AI service. */
+    private const DEFAULT_BASE_URL_EU = 'https://eu.course-ai.datacurso.com';
+
     /**
      * Constructor.
      *
      * @param string|null $licensekey The license key obtained from Datacurso SHOP.
+     * @param string|null $baseurl Optional standard-region base URL to override the default endpoint.
+     * @param string|null $baseurleu Optional EU-region base URL to override the default endpoint.
      */
-    public function __construct(?string $licensekey = null) {
+    public function __construct(?string $licensekey = null, ?string $baseurl = null, ?string $baseurleu = null) {
         if ($this->is_for_ue()) {
-            parent::__construct('https://eu.course-ai.datacurso.com', $licensekey);
+            $finalbaseurl = $baseurleu ?? self::DEFAULT_BASE_URL_EU;
         } else {
-            parent::__construct('https://course-ai.datacurso.com', $licensekey);
+            $finalbaseurl = $baseurl ?? self::DEFAULT_BASE_URL;
         }
+
+        parent::__construct($finalbaseurl, $licensekey);
     }
 
     /**

--- a/classes/httpclient/ai_services_api.php
+++ b/classes/httpclient/ai_services_api.php
@@ -28,18 +28,30 @@ require_once($CFG->libdir . '/filelib.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class ai_services_api extends datacurso_api_base {
+
+    /** Default base URL for the standard DataCurso AI service. */
+    private const DEFAULT_BASE_URL = 'https://plugins-ai.datacurso.com';
+
+    /** Default base URL for the EU-hosted DataCurso AI service. */
+    private const DEFAULT_BASE_URL_EU = 'https://eu.plugins-ai.datacurso.com';
+
     /**
      * Constructor.
      *
      * @param string|null $licensekey The license key obtained from Datacurso SHOP.
+     * @param string|null $baseurl Optional standard-region base URL to override the default endpoint.
+     * @param string|null $baseurleu Optional EU-region base URL to override the default endpoint.
      */
-    public function __construct(?string $licensekey = null) {
+    public function __construct(?string $licensekey = null, ?string $baseurl = null, ?string $baseurleu = null) {
         global $CFG;
+
         if ($this->is_for_ue()) {
-            parent::__construct('https://eu.plugins-ai.datacurso.com', $licensekey);
+            $finalbaseurl    = $baseurleu ?? self::DEFAULT_BASE_URL_EU;
         } else {
-            parent::__construct('https://plugins-ai.datacurso.com', $licensekey);
+            $finalbaseurl    = $baseurl ?? self::DEFAULT_BASE_URL;
         }
+
+        parent::__construct($finalbaseurl, $licensekey);
     }
 
     /**

--- a/classes/httpclient/ai_services_api.php
+++ b/classes/httpclient/ai_services_api.php
@@ -28,7 +28,6 @@ require_once($CFG->libdir . '/filelib.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class ai_services_api extends datacurso_api_base {
-
     /** Default base URL for the standard DataCurso AI service. */
     private const DEFAULT_BASE_URL = 'https://plugins-ai.datacurso.com';
 

--- a/classes/httpclient/datacurso_api_base.php
+++ b/classes/httpclient/datacurso_api_base.php
@@ -75,8 +75,7 @@ class datacurso_api_base {
     public function download_file($endpoint, $filename, $filerecord = []): ?\stored_file {
         global $USER;
 
-        $client = new ai_course_api();
-        $baseurl = $client->get_base_url();
+        $baseurl = $this->get_base_url();
         $packageurl = $baseurl . ltrim($endpoint, '/');
 
         $userid = $USER->id;

--- a/classes/local/user_token_limit_manager.php
+++ b/classes/local/user_token_limit_manager.php
@@ -16,8 +16,6 @@
 
 namespace aiprovider_datacurso\local;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Manager for CRUD operations over aiprovider_datacurso_userlimit.
  *

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'aiprovider_datacurso';
-$plugin->release = '1.0.6';
-$plugin->version = 2026011900;
+$plugin->release = '1.0.7';
+$plugin->version = 2026012300;
 $plugin->requires = 2024100700;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [405, 405];


### PR DESCRIPTION
**Compatibility note:** This version is compatible **only for Moodle 4.5**.

## Added
- **Configurable base URLs for DataCurso AI services**  
  Added support for configurable base URLs for both the **standard** and **EU-hosted** DataCurso AI services, allowing greater flexibility across environments.
- **Optional base URL parameters in constructors**  
  Updated service constructors to accept optional base URL parameters, enabling explicit overrides when needed.
- **CHANGE.md file for change history**  
  Added a new **CHANGE.md** file to maintain a clear, versioned history of changes and releases.


## Changed
- **Centralized base URL resolution via instance method**  
  Refactored base URL access to ensure the correct instance method is used when resolving the active base URL, improving consistency and maintainability.
- **Service initialization flow updated**  
  Adjusted internal initialization logic so all API requests correctly respect the configured base URL (standard or EU-hosted).
- **Version bump**  
  Release version bumped to **1.0.7**.
