### PR TITLE
Refactor AI service constructors to support configurable base URLs m500

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,86 @@
+## 2.0.3
+
+**Released on:** 2026-01-26
+
+**Compatibility note:** This version is compatible **from Moodle 5.0 to Moodle 5.1**.
+
+## Added
+- **Configurable base URLs for DataCurso AI services**  
+  Added support for configurable base URLs for both the **standard** and **EU-hosted** DataCurso AI services, allowing greater flexibility across environments.
+- **Optional base URL parameters in constructors**  
+  Updated service constructors to accept optional base URL parameters, enabling explicit overrides when needed.
+- **CHANGE.md file for change history**  
+  Added a new **CHANGE.md** file to maintain a clear, versioned history of changes and releases.
+
+
+## Changed
+- **Centralized base URL resolution via instance method**  
+  Refactored base URL access to ensure the correct instance method is used when resolving the active base URL, improving consistency and maintainability.
+- **Service initialization flow updated**  
+  Adjusted internal initialization logic so all API requests correctly respect the configured base URL (standard or EU-hosted).
+- **Version bump**  
+  Release version bumped to **2.0.3**.
+
+
+## 2.0.2
+
+**Released on:** 2026-01-19
+
+## Added
+
+- **Enhanced webservice setup error logging.**  
+Improved error reporting during webservice registration by including the original exception message, providing clearer diagnostics when the setup process fails.
+
+## Changed
+
+- **Improved boolean evaluation logic.**  
+Adjusted the `is_for_ue` method to ensure proper and safe boolean comparison, preventing unintended conditional behavior.
+
+## Fixed
+
+- **Webservice setup debugging limitations.**  
+Resolved an issue where webservice registration failures did not expose sufficient context, making troubleshooting difficult.
+
+## Changed
+
+- **Release bump to 2.0.2**  
+Updated the plugin version and release metadata to **2.0.2** to reflect the included improvements and fixes.
+
+## 2.0.1
+
+**Released on:** 2025-12-15
+
+**Compatibility note:** This version is compatible **only with Moodle 5.0 and 5.1**.
+
+## Added
+
+- **User-level AI credit usage limits.** 
+Introduced functionality to control and restrict AI credit consumption on a per-user basis within the Datacurso provider.
+
+## Changed
+
+- **Support updated to Moodle 5.0.** 
+The plugin now targets the **MOODLE_500_STABLE** branch and is aligned with Moodle 5.0 and 5.1
+
+- **Updated core API and rate limiter logic.** 
+Improved the `datacurso_api_base` class and rate limiter implementation to support user-specific credit limits.
+
+- **Updated provider language strings.** 
+Revised and improved provider strings for better clarity and consistency.
+
+- **Code quality and linting improvements.** 
+Fixed linting issues and applied coding standard adjustments in provider and form-related files.
+
+## Fixed
+
+- **String and character issues.** 
+Resolved issues related to string definitions that could cause compilation or display problems.
+
+- **General linting errors.** 
+Addressed additional linter warnings and errors across the codebase.
+
+## Changed
+
+- **Release bump to 2.0.1** 
+Updated the plugin release number to **2.0.1**.
+

--- a/classes/httpclient/ai_course_api.php
+++ b/classes/httpclient/ai_course_api.php
@@ -26,7 +26,6 @@ namespace aiprovider_datacurso\httpclient;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class ai_course_api extends datacurso_api_base {
-
     /** Default base URL for the standard DataCurso course AI service. */
     private const DEFAULT_BASE_URL = 'https://course-ai.datacurso.com';
 

--- a/classes/httpclient/ai_course_api.php
+++ b/classes/httpclient/ai_course_api.php
@@ -26,17 +26,28 @@ namespace aiprovider_datacurso\httpclient;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class ai_course_api extends datacurso_api_base {
+
+    /** Default base URL for the standard DataCurso course AI service. */
+    private const DEFAULT_BASE_URL = 'https://course-ai.datacurso.com';
+
+    /** Default base URL for the EU-hosted DataCurso course AI service. */
+    private const DEFAULT_BASE_URL_EU = 'https://eu.course-ai.datacurso.com';
+
     /**
      * Constructor.
      *
      * @param string|null $licensekey The license key obtained from Datacurso SHOP.
+     * @param string|null $baseurl Optional standard-region base URL to override the default endpoint.
+     * @param string|null $baseurleu Optional EU-region base URL to override the default endpoint.
      */
-    public function __construct(?string $licensekey = null) {
+    public function __construct(?string $licensekey = null, ?string $baseurl = null, ?string $baseurleu = null) {
         if ($this->is_for_ue()) {
-            parent::__construct('https://eu.course-ai.datacurso.com', $licensekey);
+            $finalbaseurl = $baseurleu ?? self::DEFAULT_BASE_URL_EU;
         } else {
-            parent::__construct('https://course-ai.datacurso.com', $licensekey);
+            $finalbaseurl = $baseurl ?? self::DEFAULT_BASE_URL;
         }
+
+        parent::__construct($finalbaseurl, $licensekey);
     }
 
     /**

--- a/classes/httpclient/ai_services_api.php
+++ b/classes/httpclient/ai_services_api.php
@@ -28,18 +28,30 @@ require_once($CFG->libdir . '/filelib.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class ai_services_api extends datacurso_api_base {
+
+    /** Default base URL for the standard DataCurso AI service. */
+    private const DEFAULT_BASE_URL = 'https://plugins-ai.datacurso.com';
+
+    /** Default base URL for the EU-hosted DataCurso AI service. */
+    private const DEFAULT_BASE_URL_EU = 'https://eu.plugins-ai.datacurso.com';
+
     /**
      * Constructor.
      *
      * @param string|null $licensekey The license key obtained from Datacurso SHOP.
+     * @param string|null $baseurl Optional standard-region base URL to override the default endpoint.
+     * @param string|null $baseurleu Optional EU-region base URL to override the default endpoint.
      */
-    public function __construct(?string $licensekey = null) {
+    public function __construct(?string $licensekey = null, ?string $baseurl = null, ?string $baseurleu = null) {
         global $CFG;
+
         if ($this->is_for_ue()) {
-            parent::__construct('https://eu.plugins-ai.datacurso.com', $licensekey);
+            $finalbaseurl    = $baseurleu ?? self::DEFAULT_BASE_URL_EU;
         } else {
-            parent::__construct('https://plugins-ai.datacurso.com', $licensekey);
+            $finalbaseurl    = $baseurl ?? self::DEFAULT_BASE_URL;
         }
+
+        parent::__construct($finalbaseurl, $licensekey);
     }
 
     /**

--- a/classes/httpclient/ai_services_api.php
+++ b/classes/httpclient/ai_services_api.php
@@ -28,7 +28,6 @@ require_once($CFG->libdir . '/filelib.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class ai_services_api extends datacurso_api_base {
-
     /** Default base URL for the standard DataCurso AI service. */
     private const DEFAULT_BASE_URL = 'https://plugins-ai.datacurso.com';
 

--- a/classes/httpclient/datacurso_api_base.php
+++ b/classes/httpclient/datacurso_api_base.php
@@ -92,8 +92,7 @@ class datacurso_api_base {
     public function download_file($endpoint, $filename, $filerecord = []): ?\stored_file {
         global $USER;
 
-        $client = new ai_course_api();
-        $baseurl = $client->get_base_url();
+        $baseurl = $this->get_base_url();
         $packageurl = $baseurl . ltrim($endpoint, '/');
 
         $userid = $USER->id;

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'aiprovider_datacurso';
-$plugin->release = '2.0.2';
+$plugin->release = '2.0.3';
 $plugin->supported = [500, 501];
-$plugin->version = 2026011901;
+$plugin->version = 2026012601;
 $plugin->requires = 2025041400;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
**Compatibility note:** This version is compatible **from Moodle 5.0 to Moodle 5.1**.

## Added
- **Configurable base URLs for DataCurso AI services**  
  Added support for configurable base URLs for both the **standard** and **EU-hosted** DataCurso AI services, allowing greater flexibility across environments.
- **Optional base URL parameters in constructors**  
  Updated service constructors to accept optional base URL parameters, enabling explicit overrides when needed.
- **CHANGE.md file for change history**  
  Added a new **CHANGE.md** file to maintain a clear, versioned history of changes and releases.