### PR TITLE
Fix fullname debug warning in rate limit user selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+## 1.0.8
+
+**Released on:** 2026-01-29
+
+**Compatibility note:** This version is compatible **with Moodle 4.5 only**.
+
+## Fixed
+- **Suppress developer debug warning when listing rate-limited users**  
+  Updated the rate-limit user selector query to load all required name fields (`firstnamephonetic`, `lastnamephonetic`, `middlename`, `alternatename`) so that `fullname()` no longer triggers the developer `debugging()` warning when building the allowed users lists.
+
+
 ## 1.0.7
 
 **Released on:** 2026-01-26

--- a/classes/local/ratelimit/ratelimit_settings.php
+++ b/classes/local/ratelimit/ratelimit_settings.php
@@ -55,7 +55,14 @@ abstract class ratelimit_settings {
         $params['capabilitiescount'] = count($capabilities);
 
         $records = $DB->get_records_sql(
-            "SELECT u.id, u.firstname, u.lastname
+            "SELECT
+                u.id,
+                u.firstname,
+                u.lastname,
+                u.firstnamephonetic,
+                u.lastnamephonetic,
+                u.middlename,
+                u.alternatename
             FROM
                 {user} u
                 JOIN {role_assignments} ra ON ra.userid = u.id

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'aiprovider_datacurso';
-$plugin->release = '1.0.7';
-$plugin->version = 2026012300;
+$plugin->release = '1.0.8';
+$plugin->version = 2026012900;
 $plugin->requires = 2024100700;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [405, 405];


### PR DESCRIPTION
**Compatibility note:** This version is compatible **with Moodle 4.5 only**.

## Fixed
- **Suppress developer debug warning when listing rate-limited users**  
  Updated the rate-limit user selector query to load all required name fields (`firstnamephonetic`, `lastnamephonetic`, `middlename`, `alternatename`) so that `fullname()` no longer triggers the developer `debugging()` warning when building the allowed users lists.