### PR TITLE
Fix fullname debug warning in rate limit user selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+## 2.0.4
+
+**Released on:** 2026-01-29
+
+**Compatibility note:** This version is compatible **from Moodle 5.0 to Moodle 5.1**.
+
+## Fixed
+- **Suppress developer debug warning when listing rate-limited users**  
+  Updated the rate-limit user selector query to load all required name fields (`firstnamephonetic`, `lastnamephonetic`, `middlename`, `alternatename`) so that `fullname()` no longer triggers the developer `debugging()` warning when building the allowed users lists.
+
+
 ## 2.0.3
 
 **Released on:** 2026-01-26

--- a/classes/local/ratelimit/ratelimit_settings.php
+++ b/classes/local/ratelimit/ratelimit_settings.php
@@ -42,7 +42,6 @@ class ratelimit_settings {
         global $DB, $CFG;
 
         [$insql, $params] = $DB->get_in_or_equal($capabilities, SQL_PARAMS_NAMED);
-        $namefields = 'u.id, u.firstname, u.lastname, u.alternatename, u.middlename, u.firstnamephonetic, u.lastnamephonetic';
 
         $params['deleted'] = 0;
         $params['suspended'] = 0;
@@ -50,7 +49,14 @@ class ratelimit_settings {
         $params['capabilitiescount'] = count($capabilities);
 
         $records = $DB->get_records_sql(
-            "SELECT {$namefields}
+            "SELECT
+                u.id,
+                u.firstname,
+                u.lastname,
+                u.firstnamephonetic,
+                u.lastnamephonetic,
+                u.middlename,
+                u.alternatename
             FROM
                 {user} u
                 JOIN {role_assignments} ra ON ra.userid = u.id

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'aiprovider_datacurso';
-$plugin->release = '2.0.3';
+$plugin->release = '2.0.4';
 $plugin->supported = [500, 501];
-$plugin->version = 2026012601;
+$plugin->version = 2026012901;
 $plugin->requires = 2025041400;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
**Compatibility note:** This version is compatible **with Moodle 4.5 only**.

## Fixed
- **Suppress developer debug warning when listing rate-limited users**  
  Updated the rate-limit user selector query to load all required name fields (`firstnamephonetic`, `lastnamephonetic`, `middlename`, `alternatename`) so that `fullname()` no longer triggers the developer `debugging()` warning when building the allowed users lists.