### PR TITLE
Enforce per-action user allowlists in rate limiter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,31 @@
+## 1.0.9
+
+**Released on:** 2026-02-10
+
+**Compatibility note:** This version is compatible **with Moodle 4.5 only**.
+
+## Fixed
+- **Fatal error when only course generation allowlist was considered**  
+  Corrected the rate limit user check that previously only evaluated the
+  `local_coursegen` course creator list, which could cause incorrect
+  access validation or fatal errors when other services or actions were
+  configured.
+
+## Added
+- **Service/action-specific allowlist handling**  
+  Extended the rate limiter so each AI-enabled service can declare its own
+  user allowlist per HTTP action path (for example, `/course/v2/start` vs
+  `/resources/create-mod`), keeping the access rules for different actions
+  completely independent.
+
+## Changed
+- **Centralised helpers and internal clean-up**  
+  Introduced small internal helpers to map paths to configuration keys and
+  to extract user ids from configuration, reducing duplication and making
+  future changes easier to maintain.
+- **Version bump**  
+  Release version bumped to **1.0.9**.
+
 ## 1.0.8
 
 **Released on:** 2026-01-29

--- a/classes/httpclient/datacurso_api_base.php
+++ b/classes/httpclient/datacurso_api_base.php
@@ -131,7 +131,7 @@ class datacurso_api_base {
         $ratelimiter = new \aiprovider_datacurso\local\ratelimiter();
 
         // Validate if user is allowed to make this request.
-        if (!empty($serviceid) && !$ratelimiter->is_user_allowed($serviceid, $userid)) {
+        if (!empty($serviceid) && !$ratelimiter->is_user_allowed($serviceid, $userid, $path)) {
             throw new \moodle_exception('notallowed', 'aiprovider_datacurso');
         }
 

--- a/classes/local/ratelimit/local_assign_ai.php
+++ b/classes/local/ratelimit/local_assign_ai.php
@@ -70,4 +70,38 @@ class local_assign_ai extends ratelimit_settings {
             )
         );
     }
+
+    /**
+     * Get the allowed user ids for local_assign_ai.
+     *
+     * Currently all actions for this service use the same
+     * "allowedusers" field.
+     *
+     * @param string $serviceid Service id, expected "local_assign_ai".
+     * @param string|null $actionpath HTTP path for the remote call.
+     * @return int[]
+     */
+    public static function get_allowed_service_user_ids(string $serviceid, ?string $actionpath): array {
+        if ($serviceid !== 'local_assign_ai') {
+            return [];
+        }
+
+        if (empty($actionpath)) {
+            return [];
+        }
+
+        $mapping = [
+            '/assign/' => 'ratelimit_local_assign_ai_allowedusers',
+        ];
+
+        $configkey = self::resolve_config_key_for_action($actionpath, $mapping);
+        if ($configkey === null) {
+            return [];
+        }
+
+        $config = get_config(self::PLUGIN);
+        $raw = $config->{$configkey} ?? '';
+
+        return self::extract_user_ids($raw);
+    }
 }

--- a/classes/local/ratelimit/local_coursegen.php
+++ b/classes/local/ratelimit/local_coursegen.php
@@ -83,4 +83,42 @@ class local_coursegen extends ratelimit_settings {
         $settings->add($activitycreators);
         $settings->hide_if("{$configprefix}_activitycreators", "{$configprefix}_allowedusers_enable", 'eq', 0);
     }
+
+    /**
+     * Get the allowed user ids for local_coursegen, separated by action path.
+     *
+     * - Course creation actions ("/course/") use the "coursecreators" field.
+     * - Activity creation actions ("/resources/create-mod") use
+     *   the "activitycreators" field.
+     * - Other actions for this service have no specific restriction.
+     *
+     * @param string $serviceid Service id, expected "local_coursegen".
+     * @param string|null $actionpath HTTP path for the remote call.
+     * @return int[]
+     */
+    public static function get_allowed_service_user_ids(string $serviceid, ?string $actionpath): array {
+        if ($serviceid !== 'local_coursegen') {
+            return [];
+        }
+
+        if (empty($actionpath)) {
+            return [];
+        }
+
+        $mapping = [
+            '/course/v2/start' => 'ratelimit_local_coursegen_coursecreators',
+            '/course/start' => 'ratelimit_local_coursegen_coursecreators',
+            '/resources/create-mod' => 'ratelimit_local_coursegen_activitycreators',
+        ];
+
+        $configkey = self::resolve_config_key_for_action($actionpath, $mapping);
+        if ($configkey === null) {
+            return [];
+        }
+
+        $config = get_config(self::PLUGIN);
+        $raw = $config->{$configkey} ?? '';
+
+        return self::extract_user_ids($raw);
+    }
 }

--- a/classes/local/ratelimit/local_datacurso_ratings.php
+++ b/classes/local/ratelimit/local_datacurso_ratings.php
@@ -84,4 +84,40 @@ class local_datacurso_ratings extends ratelimit_settings {
         $settings->add($generalanalysts);
         $settings->hide_if("{$configprefix}_generalanalysts", "{$configprefix}_allowedusers_enable", 'eq', 0);
     }
+
+    /**
+     * Get the allowed user ids for local_datacurso_ratings, by action.
+     *
+     * - "/rating/course" and "/rating/query" use the "courseanalysts" field.
+     * - "/rating/general" uses the "generalanalysts" field.
+     *
+     * @param string $serviceid Service id, expected "local_datacurso_ratings".
+     * @param string|null $actionpath HTTP path for the remote call.
+     * @return int[]
+     */
+    public static function get_allowed_service_user_ids(string $serviceid, ?string $actionpath): array {
+        if ($serviceid !== 'local_datacurso_ratings') {
+            return [];
+        }
+
+        if (empty($actionpath)) {
+            return [];
+        }
+
+        $mapping = [
+            '/rating/course' => 'ratelimit_local_datacurso_ratings_courseanalysts',
+            '/rating/query' => 'ratelimit_local_datacurso_ratings_courseanalysts',
+            '/rating/general' => 'ratelimit_local_datacurso_ratings_generalanalysts',
+        ];
+
+        $configkey = self::resolve_config_key_for_action($actionpath, $mapping);
+        if ($configkey === null) {
+            return [];
+        }
+
+        $config = get_config(self::PLUGIN);
+        $raw = $config->{$configkey} ?? '';
+
+        return self::extract_user_ids($raw);
+    }
 }

--- a/classes/local/ratelimit/ratelimit_settings.php
+++ b/classes/local/ratelimit/ratelimit_settings.php
@@ -39,6 +39,95 @@ abstract class ratelimit_settings {
     abstract public function add_settings(\admin_settingpage $settings, string $component): void;
 
     /**
+     * Return the list of allowed user ids for a given service/action pair.
+     *
+     * Each subclass should implement this method and restrict the result to the
+     * specific config fields that correspond to the given action path, without
+     * mezclar usuarios de distintas acciones.
+     *
+     * When no specific restriction applies, subclasses should return an empty
+     * array to indicate that there is no per-user restriction for that
+     * service/action pair.
+     *
+     * @param string $serviceid Frankenstyle service/component id (e.g. 'local_coursegen').
+     * @param string|null $actionpath Optional HTTP path used to route to the correct list.
+     * @return int[] List of allowed user ids for this service/action only.
+     */
+    abstract public static function get_allowed_service_user_ids(string $serviceid, ?string $actionpath): array;
+
+    /**
+     * Resolve and delegate to the concrete ratelimit settings class for a service.
+     *
+     * This uses the convention that the service id matches the class name in this
+     * namespace (for example serviceid "local_coursegen" -> class
+     * aiprovider_datacurso\local\ratelimit\local_coursegen).
+     *
+     * @param string $serviceid Frankenstyle service/component id.
+     * @param string|null $actionpath Optional HTTP path used to route to the correct list.
+     * @return int[] List of allowed user ids for this service/action only.
+     */
+    public static function get_allowed_users_for_service(string $serviceid, ?string $actionpath): array {
+        $classname = "aiprovider_datacurso\\local\\ratelimit\\" . $serviceid;
+
+        if (!class_exists($classname)) {
+            return [];
+        }
+
+        if (!is_subclass_of($classname, self::class)) {
+            return [];
+        }
+
+        return $classname::get_allowed_service_user_ids($serviceid, $actionpath);
+    }
+
+    /**
+     * Resolve a configuration key for a given action path using a
+     * prefix-to-config mapping.
+     *
+     * @param string|null $actionpath HTTP path for the remote call.
+     * @param array $mapping Array in the form prefix => configname.
+     * @return string|null Config key name or null when no prefix matches.
+     */
+    protected static function resolve_config_key_for_action(?string $actionpath, array $mapping): ?string {
+        if (empty($actionpath)) {
+            return null;
+        }
+
+        foreach ($mapping as $prefix => $configname) {
+            if (str_starts_with($actionpath, $prefix)) {
+                return $configname;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract user ids from a comma-separated configuration value.
+     *
+     * @param string $value Raw configuration value.
+     * @return int[]
+     */
+    protected static function extract_user_ids(string $value): array {
+        if ($value === '') {
+            return [];
+        }
+
+        $parts = explode(',', $value);
+        $ids = [];
+
+        foreach ($parts as $part) {
+            $part = trim($part);
+            if ($part === '') {
+                continue;
+            }
+            $ids[] = (int)$part;
+        }
+
+        return $ids;
+    }
+
+    /**
      * Retrieve the list of selectable users for the autocomplete control.
      *
      * @param array $capabilities Capability names users must have to be selectable.

--- a/classes/local/ratelimit/report_lifestory.php
+++ b/classes/local/ratelimit/report_lifestory.php
@@ -66,4 +66,37 @@ class report_lifestory extends ratelimit_settings {
         ));
         $settings->hide_if("{$configprefix}_allowedusers", "{$configprefix}_allowedusers_enable", 'eq', 0);
     }
+
+    /**
+     * Get the allowed user ids for report_lifestory.
+     *
+     * Only the "/story/analysis" action has a specific restriction.
+     *
+     * @param string $serviceid Service id, expected "report_lifestory".
+     * @param string|null $actionpath HTTP path for the remote call.
+     * @return int[]
+     */
+    public static function get_allowed_service_user_ids(string $serviceid, ?string $actionpath): array {
+        if ($serviceid !== 'report_lifestory') {
+            return [];
+        }
+
+        if (empty($actionpath)) {
+            return [];
+        }
+
+        $mapping = [
+            '/story/analysis' => 'ratelimit_report_lifestory_allowedusers',
+        ];
+
+        $configkey = self::resolve_config_key_for_action($actionpath, $mapping);
+        if ($configkey === null) {
+            return [];
+        }
+
+        $config = get_config(self::PLUGIN);
+        $raw = $config->{$configkey} ?? '';
+
+        return self::extract_user_ids($raw);
+    }
 }

--- a/classes/local/ratelimiter.php
+++ b/classes/local/ratelimiter.php
@@ -25,19 +25,21 @@ namespace aiprovider_datacurso\local;
  */
 class ratelimiter {
     /**
-     * Determine if the given user is allowed to use a service.
+     * Determine if the given user is allowed to use a service (and optional action).
      *
      * This checks, in order:
      * - Empty service id: allow.
      * - Site administrators: always allow.
      * - If user restriction for the service is disabled: allow.
-     * - Otherwise, only allow users listed in the configured allowed users list for the service.
+     * - Otherwise, only allow users listed in the configured allowed users list
+     *   for the specific service/action pair.
      *
      * @param string $serviceid Service identifier such as 'local_coursegen'.
      * @param int $userid Moodle user id.
+     * @param string|null $actionpath Optional HTTP path used to route the request.
      * @return bool True if the user is allowed to access the service, false otherwise.
      */
-    public function is_user_allowed(string $serviceid, int $userid): bool {
+    public function is_user_allowed(string $serviceid, int $userid, ?string $actionpath = null): bool {
         if (empty($serviceid)) {
             return true;
         }
@@ -50,15 +52,20 @@ class ratelimiter {
             return true;
         }
 
-        $settings = get_config('aiprovider_datacurso');
-        $coursecreators = $settings->ratelimit_local_coursegen_coursecreators ?? '';
+        // Delegate to the ratelimit settings class for this service in order to
+        // keep per-action user lists isolated.
+        $alloweduserids = \aiprovider_datacurso\local\ratelimit\ratelimit_settings::get_allowed_users_for_service(
+            $serviceid,
+            $actionpath
+        );
 
-        $coursecreators = explode(',', $coursecreators);
-        if (empty($coursecreators)) {
+        // When there is no specific list for this service/action, treat it as
+        // unrestricted.
+        if (empty($alloweduserids)) {
             return true;
         }
 
-        return in_array($userid, $coursecreators);
+        return in_array($userid, $alloweduserids, true);
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'aiprovider_datacurso';
-$plugin->release = '1.0.8';
-$plugin->version = 2026012900;
+$plugin->release = '1.0.9';
+$plugin->version = 2026021000;
 $plugin->requires = 2024100700;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [405, 405];


### PR DESCRIPTION
**Compatibility note:** This version is compatible **with Moodle 4.5 only**.

## Fixed
- **Fatal error when only course generation allowlist was considered**  
  Corrected the rate limit user check that previously only evaluated the
  `local_coursegen` course creator list, which could cause incorrect
  access validation or fatal errors when other services or actions were
  configured.

## Added
- **Service/action-specific allowlist handling**  
  Extended the rate limiter so each AI-enabled service can declare its own
  user allowlist per HTTP action path (for example, `/course/v2/start` vs
  `/resources/create-mod`), keeping the access rules for different actions
  completely independent.

## Changed
- **Centralised helpers and internal clean-up**  
  Introduced small internal helpers to map paths to configuration keys and
  to extract user ids from configuration, reducing duplication and making
  future changes easier to maintain.
- **Version bump**  
  Release version bumped to **1.0.9**.