### PR TITLE
Enforce per-action user allowlists in rate limiter for moodle 5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,31 @@
+## 2.0.5
+
+**Released on:** 2026-02-10
+
+**Compatibility note:** This version is compatible **from Moodle 5.0 to Moodle 5.1**.
+
+## Fixed
+- **Fatal error when only course generation allowlist was considered**  
+  Corrected the rate limit user check that previously only evaluated the
+  `local_coursegen` course creator list, which could cause incorrect
+  access validation or fatal errors when other services or actions were
+  configured.
+
+## Added
+- **Service/action-specific allowlist handling**  
+  Extended the rate limiter so each AI-enabled service can declare its own
+  user allowlist per HTTP action path (for example, `/course/v2/start` vs
+  `/resources/create-mod`), keeping the access rules for different actions
+  completely independent.
+
+## Changed
+- **Centralised helpers and internal clean-up**  
+  Introduced small internal helpers to map paths to configuration keys and
+  to extract user ids from configuration, reducing duplication and making
+  future changes easier to maintain.
+- **Version bump**  
+  Release version bumped to **2.0.5**.
+
 ## 2.0.4
 
 **Released on:** 2026-01-29

--- a/classes/httpclient/datacurso_api_base.php
+++ b/classes/httpclient/datacurso_api_base.php
@@ -149,7 +149,7 @@ class datacurso_api_base {
         $ratelimiter = new \aiprovider_datacurso\local\ratelimiter($this->instanceprovider);
 
         // Validate if user is allowed to make this request.
-        if (!empty($serviceid) && !$ratelimiter->is_user_allowed($serviceid, $userid)) {
+        if (!empty($serviceid) && !$ratelimiter->is_user_allowed($serviceid, $userid, $path)) {
             throw new \moodle_exception('notallowed', 'aiprovider_datacurso');
         }
 

--- a/classes/local/ratelimit/local_assign_ai.php
+++ b/classes/local/ratelimit/local_assign_ai.php
@@ -73,4 +73,38 @@ class local_assign_ai {
 
         $mform->hideIf($allowedusersid, $allowedusersenableid, 'notchecked');
     }
+
+    /**
+     * Get the allowed user ids for local_assign_ai.
+     *
+     * Currently all actions for this service use the same
+     * "allowedusers" field.
+     *
+     * @param string $serviceid Service id, expected "local_assign_ai".
+     * @param string|null $actionpath HTTP path for the remote call.
+     * @return int[]
+     */
+    public static function get_allowed_service_user_ids(string $serviceid, ?string $actionpath): array {
+        if ($serviceid !== 'local_assign_ai') {
+            return [];
+        }
+
+        if (empty($actionpath)) {
+            return [];
+        }
+
+        $mapping = [
+            '/assign/' => 'ratelimit_local_assign_ai_allowedusers',
+        ];
+
+        $configkey = self::resolve_config_key_for_action($actionpath, $mapping);
+        if ($configkey === null) {
+            return [];
+        }
+
+        $config = get_config(self::PLUGIN);
+        $raw = $config->{$configkey} ?? '';
+
+        return self::extract_user_ids($raw);
+    }
 }

--- a/classes/local/ratelimit/local_coursegen.php
+++ b/classes/local/ratelimit/local_coursegen.php
@@ -96,4 +96,42 @@ class local_coursegen {
         // Hide if the master checkbox is not checked (eq, 0).
         $mform->hideIf($activitycreatorsid, $allowedusersenableid, 'notchecked');
     }
+
+    /**
+     * Get the allowed user ids for local_coursegen, separated by action path.
+     *
+     * - Course creation actions ("/course/") use the "coursecreators" field.
+     * - Activity creation actions ("/resources/create-mod") use
+     *   the "activitycreators" field.
+     * - Other actions for this service have no specific restriction.
+     *
+     * @param string $serviceid Service id, expected "local_coursegen".
+     * @param string|null $actionpath HTTP path for the remote call.
+     * @return int[]
+     */
+    public static function get_allowed_service_user_ids(string $serviceid, ?string $actionpath): array {
+        if ($serviceid !== 'local_coursegen') {
+            return [];
+        }
+
+        if (empty($actionpath)) {
+            return [];
+        }
+
+        $mapping = [
+            '/course/v2/start' => 'ratelimit_local_coursegen_coursecreators',
+            '/course/start' => 'ratelimit_local_coursegen_coursecreators',
+            '/resources/create-mod' => 'ratelimit_local_coursegen_activitycreators',
+        ];
+
+        $configkey = self::resolve_config_key_for_action($actionpath, $mapping);
+        if ($configkey === null) {
+            return [];
+        }
+
+        $config = get_config(self::PLUGIN);
+        $raw = $config->{$configkey} ?? '';
+
+        return self::extract_user_ids($raw);
+    }
 }

--- a/classes/local/ratelimit/local_datacurso_ratings.php
+++ b/classes/local/ratelimit/local_datacurso_ratings.php
@@ -95,4 +95,40 @@ class local_datacurso_ratings {
         // Hide if the master checkbox is not checked.
         $mform->hideIf($generalanalystsid, $allowedusersenableid, 'notchecked');
     }
+
+    /**
+     * Get the allowed user ids for local_datacurso_ratings, by action.
+     *
+     * - "/rating/course" and "/rating/query" use the "courseanalysts" field.
+     * - "/rating/general" uses the "generalanalysts" field.
+     *
+     * @param string $serviceid Service id, expected "local_datacurso_ratings".
+     * @param string|null $actionpath HTTP path for the remote call.
+     * @return int[]
+     */
+    public static function get_allowed_service_user_ids(string $serviceid, ?string $actionpath): array {
+        if ($serviceid !== 'local_datacurso_ratings') {
+            return [];
+        }
+
+        if (empty($actionpath)) {
+            return [];
+        }
+
+        $mapping = [
+            '/rating/course' => 'ratelimit_local_datacurso_ratings_courseanalysts',
+            '/rating/query' => 'ratelimit_local_datacurso_ratings_courseanalysts',
+            '/rating/general' => 'ratelimit_local_datacurso_ratings_generalanalysts',
+        ];
+
+        $configkey = self::resolve_config_key_for_action($actionpath, $mapping);
+        if ($configkey === null) {
+            return [];
+        }
+
+        $config = get_config(self::PLUGIN);
+        $raw = $config->{$configkey} ?? '';
+
+        return self::extract_user_ids($raw);
+    }
 }

--- a/classes/local/ratelimit/ratelimit_settings.php
+++ b/classes/local/ratelimit/ratelimit_settings.php
@@ -35,19 +35,17 @@ class ratelimit_settings {
     /**
      * Return the list of allowed user ids for a given service/action pair.
      *
-     * Each subclass should implement this method and restrict the result to the
-     * specific config fields that correspond to the given action path, without
-     * mezclar usuarios de distintas acciones.
-     *
-     * When no specific restriction applies, subclasses should return an empty
-     * array to indicate that there is no per-user restriction for that
-     * service/action pair.
+     * Implementing classes may provide a service-specific version of this
+     * method. The base implementation returns an empty array meaning that
+     * there is no per-user restriction for the given service/action pair.
      *
      * @param string $serviceid Frankenstyle service/component id (e.g. 'local_coursegen').
      * @param string|null $actionpath Optional HTTP path used to route to the correct list.
      * @return int[] List of allowed user ids for this service/action only.
      */
-    abstract public static function get_allowed_service_user_ids(string $serviceid, ?string $actionpath): array;
+    public static function get_allowed_service_user_ids(string $serviceid, ?string $actionpath): array {
+        return [];
+    }
 
     /**
      * Resolve and delegate to the concrete ratelimit settings class for a service.
@@ -67,7 +65,10 @@ class ratelimit_settings {
             return [];
         }
 
-        if (!is_subclass_of($classname, self::class)) {
+        // Only call the method when the target class exposes the expected
+        // static API. This keeps service classes decoupled from inheritance
+        // while still allowing them to provide their own allowlist logic.
+        if (!method_exists($classname, 'get_allowed_service_user_ids')) {
             return [];
         }
 

--- a/classes/local/ratelimit/ratelimit_settings.php
+++ b/classes/local/ratelimit/ratelimit_settings.php
@@ -33,6 +33,95 @@ namespace aiprovider_datacurso\local\ratelimit;
  */
 class ratelimit_settings {
     /**
+     * Return the list of allowed user ids for a given service/action pair.
+     *
+     * Each subclass should implement this method and restrict the result to the
+     * specific config fields that correspond to the given action path, without
+     * mezclar usuarios de distintas acciones.
+     *
+     * When no specific restriction applies, subclasses should return an empty
+     * array to indicate that there is no per-user restriction for that
+     * service/action pair.
+     *
+     * @param string $serviceid Frankenstyle service/component id (e.g. 'local_coursegen').
+     * @param string|null $actionpath Optional HTTP path used to route to the correct list.
+     * @return int[] List of allowed user ids for this service/action only.
+     */
+    abstract public static function get_allowed_service_user_ids(string $serviceid, ?string $actionpath): array;
+
+    /**
+     * Resolve and delegate to the concrete ratelimit settings class for a service.
+     *
+     * This uses the convention that the service id matches the class name in this
+     * namespace (for example serviceid "local_coursegen" -> class
+     * aiprovider_datacurso\local\ratelimit\local_coursegen).
+     *
+     * @param string $serviceid Frankenstyle service/component id.
+     * @param string|null $actionpath Optional HTTP path used to route to the correct list.
+     * @return int[] List of allowed user ids for this service/action only.
+     */
+    public static function get_allowed_users_for_service(string $serviceid, ?string $actionpath): array {
+        $classname = "aiprovider_datacurso\\local\\ratelimit\\" . $serviceid;
+
+        if (!class_exists($classname)) {
+            return [];
+        }
+
+        if (!is_subclass_of($classname, self::class)) {
+            return [];
+        }
+
+        return $classname::get_allowed_service_user_ids($serviceid, $actionpath);
+    }
+
+    /**
+     * Resolve a configuration key for a given action path using a
+     * prefix-to-config mapping.
+     *
+     * @param string|null $actionpath HTTP path for the remote call.
+     * @param array $mapping Array in the form prefix => configname.
+     * @return string|null Config key name or null when no prefix matches.
+     */
+    protected static function resolve_config_key_for_action(?string $actionpath, array $mapping): ?string {
+        if (empty($actionpath)) {
+            return null;
+        }
+
+        foreach ($mapping as $prefix => $configname) {
+            if (str_starts_with($actionpath, $prefix)) {
+                return $configname;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract user ids from a comma-separated configuration value.
+     *
+     * @param string $value Raw configuration value.
+     * @return int[]
+     */
+    protected static function extract_user_ids(string $value): array {
+        if ($value === '') {
+            return [];
+        }
+
+        $parts = explode(',', $value);
+        $ids = [];
+
+        foreach ($parts as $part) {
+            $part = trim($part);
+            if ($part === '') {
+                continue;
+            }
+            $ids[] = (int)$part;
+        }
+
+        return $ids;
+    }
+
+    /**
      * Retrieve the list of selectable users for the autocomplete control.
      *
      * @param array $capabilities Capability names users must have to be selectable.

--- a/classes/local/ratelimit/report_lifestory.php
+++ b/classes/local/ratelimit/report_lifestory.php
@@ -77,4 +77,37 @@ class report_lifestory {
         // Hide if the master checkbox is not checked.
         $mform->hideIf($allowedusersid, $allowedusersenableid, 'notchecked');
     }
+
+    /**
+     * Get the allowed user ids for report_lifestory.
+     *
+     * Only the "/story/analysis" action has a specific restriction.
+     *
+     * @param string $serviceid Service id, expected "report_lifestory".
+     * @param string|null $actionpath HTTP path for the remote call.
+     * @return int[]
+     */
+    public static function get_allowed_service_user_ids(string $serviceid, ?string $actionpath): array {
+        if ($serviceid !== 'report_lifestory') {
+            return [];
+        }
+
+        if (empty($actionpath)) {
+            return [];
+        }
+
+        $mapping = [
+            '/story/analysis' => 'ratelimit_report_lifestory_allowedusers',
+        ];
+
+        $configkey = self::resolve_config_key_for_action($actionpath, $mapping);
+        if ($configkey === null) {
+            return [];
+        }
+
+        $config = get_config(self::PLUGIN);
+        $raw = $config->{$configkey} ?? '';
+
+        return self::extract_user_ids($raw);
+    }
 }

--- a/classes/local/ratelimiter.php
+++ b/classes/local/ratelimiter.php
@@ -37,19 +37,21 @@ class ratelimiter {
     }
 
     /**
-     * Determine if the given user is allowed to use a service.
+     * Determine if the given user is allowed to use a service (and optional action).
      *
      * This checks, in order:
      * - Empty service id: allow.
      * - Site administrators: always allow.
      * - If user restriction for the service is disabled: allow.
-     * - Otherwise, only allow users listed in the configured allowed users list for the service.
+     * - Otherwise, only allow users listed in the configured allowed users list
+     *   for the specific service/action pair.
      *
      * @param string $serviceid Service identifier such as 'local_coursegen'.
      * @param int $userid Moodle user id.
+     * @param string|null $actionpath Optional HTTP path used to route the request.
      * @return bool True if the user is allowed to access the service, false otherwise.
      */
-    public function is_user_allowed(string $serviceid, int $userid): bool {
+    public function is_user_allowed(string $serviceid, int $userid, ?string $actionpath = null): bool {
         if (empty($serviceid)) {
             return true;
         }
@@ -62,14 +64,20 @@ class ratelimiter {
             return true;
         }
 
-        $settings = $this->instanceprovider->config ?? [];
-        $coursecreators = $settings['ratelimit_local_coursegen_coursecreators'] ?? [];
+        // Delegate to the ratelimit settings class for this service in order to
+        // keep per-action user lists isolated.
+        $alloweduserids = \aiprovider_datacurso\local\ratelimit\ratelimit_settings::get_allowed_users_for_service(
+            $serviceid,
+            $actionpath
+        );
 
-        if (empty($coursecreators)) {
+        // When there is no specific list for this service/action, treat it as
+        // unrestricted.
+        if (empty($alloweduserids)) {
             return true;
         }
 
-        return in_array($userid, $coursecreators);
+        return in_array($userid, $alloweduserids, true);
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'aiprovider_datacurso';
-$plugin->release = '2.0.4';
+$plugin->release = '2.0.5';
 $plugin->supported = [500, 501];
-$plugin->version = 2026012901;
+$plugin->version = 2026021001;
 $plugin->requires = 2025041400;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
**Compatibility note:** This version is compatible **from Moodle 5.0 to Moodle 5.1**.

## Fixed
- **Fatal error when only course generation allowlist was considered**  
  Corrected the rate limit user check that previously only evaluated the
  `local_coursegen` course creator list, which could cause incorrect
  access validation or fatal errors when other services or actions were
  configured.

## Added
- **Service/action-specific allowlist handling**  
  Extended the rate limiter so each AI-enabled service can declare its own
  user allowlist per HTTP action path (for example, `/course/v2/start` vs
  `/resources/create-mod`), keeping the access rules for different actions
  completely independent.

## Changed
- **Centralised helpers and internal clean-up**  
  Introduced small internal helpers to map paths to configuration keys and
  to extract user ids from configuration, reducing duplication and making
  future changes easier to maintain.
- **Version bump**  
  Release version bumped to **2.0.5**.