### PR TITLE
make ratelimit_settings non-abstract and relax service binding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,24 @@
+## 1.0.10
+
+**Released on:** 2026-02-10
+
+**Compatibility note:** This version is compatible **with Moodle 4.5 only**.
+
+## Fixed
+- **Abstract ratelimit_settings caused fatal error**  
+  Resolved a fatal error triggered when `ratelimit_settings` was treated as
+  an abstract class while service-specific rate limit classes no longer
+  extended it.
+
+## Changed
+- **Relaxed service binding for allowlist resolution**  
+  Updated `ratelimit_settings::get_allowed_users_for_service()` to call the
+  static `get_allowed_service_user_ids()` method only when it exists on the
+  target service class, removing the hard requirement for inheritance and
+  keeping services decoupled from the base helper.
+- **Version bump**  
+  Release version bumped to **1.0.10**.
+
 ## 1.0.9
 
 **Released on:** 2026-02-10

--- a/classes/local/ratelimit/ratelimit_settings.php
+++ b/classes/local/ratelimit/ratelimit_settings.php
@@ -41,19 +41,17 @@ abstract class ratelimit_settings {
     /**
      * Return the list of allowed user ids for a given service/action pair.
      *
-     * Each subclass should implement this method and restrict the result to the
-     * specific config fields that correspond to the given action path, without
-     * mezclar usuarios de distintas acciones.
-     *
-     * When no specific restriction applies, subclasses should return an empty
-     * array to indicate that there is no per-user restriction for that
-     * service/action pair.
+     * Implementing classes may provide a service-specific version of this
+     * method. The base implementation returns an empty array meaning that
+     * there is no per-user restriction for the given service/action pair.
      *
      * @param string $serviceid Frankenstyle service/component id (e.g. 'local_coursegen').
      * @param string|null $actionpath Optional HTTP path used to route to the correct list.
      * @return int[] List of allowed user ids for this service/action only.
      */
-    abstract public static function get_allowed_service_user_ids(string $serviceid, ?string $actionpath): array;
+    public static function get_allowed_service_user_ids(string $serviceid, ?string $actionpath): array {
+        return [];
+    }
 
     /**
      * Resolve and delegate to the concrete ratelimit settings class for a service.
@@ -73,7 +71,10 @@ abstract class ratelimit_settings {
             return [];
         }
 
-        if (!is_subclass_of($classname, self::class)) {
+        // Only call the method when the target class exposes the expected
+        // static API. This keeps service classes decoupled from inheritance
+        // while still allowing them to provide their own allowlist logic.
+        if (!method_exists($classname, 'get_allowed_service_user_ids')) {
             return [];
         }
 

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'aiprovider_datacurso';
-$plugin->release = '1.0.9';
-$plugin->version = 2026021000;
+$plugin->release = '1.0.10';
+$plugin->version = 2026021002;
 $plugin->requires = 2024100700;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [405, 405];


### PR DESCRIPTION
**Compatibility note:** This version is compatible **with Moodle 4.5 only**.

## Fixed
- **Abstract ratelimit_settings caused fatal error**  
  Resolved a fatal error triggered when `ratelimit_settings` was treated as
  an abstract class while service-specific rate limit classes no longer
  extended it.

## Changed
- **Relaxed service binding for allowlist resolution**  
  Updated `ratelimit_settings::get_allowed_users_for_service()` to call the
  static `get_allowed_service_user_ids()` method only when it exists on the
  target service class, removing the hard requirement for inheritance and
  keeping services decoupled from the base helper.
- **Version bump**  
  Release version bumped to **1.0.10**.