### PR TITLE
perf(aiprovider_datacurso): optimize ratelimit settings class lookup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+## 1.1.5
+
+**Released on:** 2026-04-29
+
+**Compatibility note:** This version is compatible **with Moodle 4.5 only**.
+
+## Changed
+- **Optimized ratelimit settings class lookup in admin settings**  
+  Replaced dynamic class discovery per service with an explicit service-to-class map in the provider, reducing unnecessary autoload checks when loading plugin settings.
+- **Added tests for ratelimit settings mapping**  
+  Added PHPUnit coverage for known and unknown service ids to ensure class resolution remains predictable and maintainable.
+
 ## 1.0.10
 
 **Released on:** 2026-02-10

--- a/classes/provider.php
+++ b/classes/provider.php
@@ -28,6 +28,14 @@ class provider extends \core_ai\provider {
     /** @var mixed License key for Datacurso API. */
     private mixed $licensekey;
 
+    /** @var array<string,string> Service id => ratelimit settings class map. */
+    private const RATELIMIT_SETTINGS_CLASSES = [
+        'local_assign_ai' => \aiprovider_datacurso\local\ratelimit\local_assign_ai::class,
+        'local_coursegen' => \aiprovider_datacurso\local\ratelimit\local_coursegen::class,
+        'local_datacurso_ratings' => \aiprovider_datacurso\local\ratelimit\local_datacurso_ratings::class,
+        'report_lifestory' => \aiprovider_datacurso\local\ratelimit\report_lifestory::class,
+    ];
+
     /**
      * Builder.
      */
@@ -127,6 +135,16 @@ class provider extends \core_ai\provider {
             ['id' => 'report_lifestory', 'name' => get_string('pluginname_lifestory', 'aiprovider_datacurso')],
             ['id' => 'local_coursedynamicrules', 'name' => get_string('pluginname_smartrules', 'aiprovider_datacurso')],
         ];
+    }
+
+    /**
+     * Return the ratelimit settings class for a service when available.
+     *
+     * @param string $serviceid Service component id.
+     * @return string|null Fully-qualified class name or null.
+     */
+    public static function get_ratelimit_settings_class(string $serviceid): ?string {
+        return self::RATELIMIT_SETTINGS_CLASSES[$serviceid] ?? null;
     }
 
     /**

--- a/settings.php
+++ b/settings.php
@@ -61,6 +61,7 @@ if ($hassiteconfig) {
 
     // Order services by name.
     \core_collator::asort_array_of_arrays_by_key($services, 'name');
+    $ratelimitsettingsinterface = \aiprovider_datacurso\local\ratelimit\ratelimit_settings::class;
     foreach ($services as $service) {
         $sid = $service['id'];
         $sname = $service['name'];
@@ -98,9 +99,8 @@ if ($hassiteconfig) {
         ));
         $settings->hide_if("aiprovider_datacurso/ratelimit_{$sid}_window", "aiprovider_datacurso/ratelimit_{$sid}_enable", 'eq', 0);
 
-        $classname = "\\aiprovider_datacurso\\local\\ratelimit\\{$sid}";
-        $iface = \aiprovider_datacurso\local\ratelimit\ratelimit_settings::class;
-        if (class_exists($classname) && is_subclass_of($classname, $iface)) {
+        $classname = \aiprovider_datacurso\provider::get_ratelimit_settings_class($sid);
+        if ($classname !== null && is_subclass_of($classname, $ratelimitsettingsinterface)) {
             $provider = new $classname();
             $provider->add_settings($settings, $sid);
         }

--- a/tests/provider_test.php
+++ b/tests/provider_test.php
@@ -1,0 +1,61 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace aiprovider_datacurso;
+
+/**
+ * Provider tests for Datacurso AI provider.
+ *
+ * @package    aiprovider_datacurso
+ * @category   test
+ * @copyright  2026 Industria Elearning
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class provider_test extends \basic_testcase {
+    /**
+     * Ensure known services map to their explicit ratelimit settings class.
+     *
+     * @covers \aiprovider_datacurso\provider::get_ratelimit_settings_class
+     */
+    public function test_get_ratelimit_settings_class_for_known_services(): void {
+        $this->assertSame(
+            \aiprovider_datacurso\local\ratelimit\local_coursegen::class,
+            provider::get_ratelimit_settings_class('local_coursegen')
+        );
+        $this->assertSame(
+            \aiprovider_datacurso\local\ratelimit\local_datacurso_ratings::class,
+            provider::get_ratelimit_settings_class('local_datacurso_ratings')
+        );
+        $this->assertSame(
+            \aiprovider_datacurso\local\ratelimit\local_assign_ai::class,
+            provider::get_ratelimit_settings_class('local_assign_ai')
+        );
+        $this->assertSame(
+            \aiprovider_datacurso\local\ratelimit\report_lifestory::class,
+            provider::get_ratelimit_settings_class('report_lifestory')
+        );
+    }
+
+    /**
+     * Ensure services without extension class do not trigger dynamic lookup.
+     *
+     * @covers \aiprovider_datacurso\provider::get_ratelimit_settings_class
+     */
+    public function test_get_ratelimit_settings_class_for_unknown_services(): void {
+        $this->assertNull(provider::get_ratelimit_settings_class('local_forum_ai'));
+        $this->assertNull(provider::get_ratelimit_settings_class('aiprovider_datacurso'));
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'aiprovider_datacurso';
-$plugin->release = '1.1.4';
-$plugin->version = 2026042200;
+$plugin->release = '1.1.5';
+$plugin->version = 2026042900;
 $plugin->requires = 2024100700;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [405, 405];


### PR DESCRIPTION
### Context

The plugin settings page used dynamic class discovery for each service (`class_exists` + `is_subclass_of`) while building ratelimit controls. This adds avoidable autoload checks and makes service-to-class wiring less explicit.

### Description

- Added an explicit service-to-ratelimit-settings class map in the provider
- Replaced dynamic class name building in `settings.php` with mapped lookup via `provider::get_ratelimit_settings_class()`
- Added PHPUnit coverage for known and unknown service id mappings
- Updated `version.php` (`release` and `version`) and `CHANGES.md` for this branch delta

### Steps to review

1. Open the provider settings page: `Site administration > Plugins > AI > DataCurso provider`
2. Confirm ratelimit settings still render for mapped services (`local_coursegen`, `local_datacurso_ratings`, `local_assign_ai`, `report_lifestory`)
3. Confirm services without mapped classes do not trigger errors and still keep base ratelimit controls
4. Run tests and lint commands listed below

### Checklist

- [ ] Scope is clearly defined (component/plugin)
- [ ] Review if the code is covered by tests
- [ ] Review if documentation updates are needed
- [ ] Review if backport is needed
- [ ] Ensure new entries are added to `CHANGES.md`, if applicable
- [ ] Validate plugin version from `version.php`, if applicable

#### Plugin-specific checks (if applicable)

- [ ] `CHANGES.md` exists in plugin root
- [ ] `version.php` exists in plugin root
- [ ] Changelog/version consistency validated from plugin directory

### Validation performed

```bash
php -l classes/provider.php
php -l settings.php
php -l version.php
php -l tests/provider_test.php

docker compose -f ../compose.yml exec -T -w /var/www/html company1.moodle php admin/tool/phpunit/cli/init.php
docker compose -f ../compose.yml exec -T -w /var/www/html company1.moodle vendor/bin/phpunit ai/provider/datacurso/tests/provider_test.php
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the project license.