### PR TITLE
fix(aiprovider_datacurso): remove unexpected legacy rl table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## 1.1.6
+
+**Released on:** 2026-04-29
+
+**Compatibility note:** This version is compatible **with Moodle 4.5 only**.
+
+## Fixed
+- **Removed legacy `aiprovider_datacurso_rl` table on upgrade**  
+  Added an upgrade step to drop the deprecated table left behind after the ratelimit table rename, preventing schema checker errors such as `aiprovider_datacurso_rl table is not expected`.
+
+## Added
+- **Upgrade regression test for legacy table cleanup**  
+  Added a PHPUnit test to cover the upgrade path that removes the old ratelimit table.
+
 ## 1.1.5
 
 **Released on:** 2026-04-29

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -186,5 +186,15 @@ function xmldb_aiprovider_datacurso_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026042200, 'aiprovider', 'datacurso');
     }
 
+    if ($oldversion < 2026042901) {
+        $legacytable = new xmldb_table('aiprovider_datacurso_rl');
+
+        if ($dbman->table_exists($legacytable)) {
+            $dbman->drop_table($legacytable);
+        }
+
+        upgrade_plugin_savepoint(true, 2026042901, 'aiprovider', 'datacurso');
+    }
+
     return true;
 }

--- a/tests/upgrade_test.php
+++ b/tests/upgrade_test.php
@@ -1,0 +1,72 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace aiprovider_datacurso;
+
+/**
+ * Upgrade tests for Datacurso AI provider.
+ *
+ * @package    aiprovider_datacurso
+ * @category   test
+ * @copyright  2026 Industria Elearning
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class upgrade_test extends \advanced_testcase {
+    /**
+     * Ensure upgrade removes the legacy ratelimit table.
+     *
+     * @covers \xmldb_aiprovider_datacurso_upgrade
+     */
+    public function test_upgrade_removes_legacy_ratelimit_table(): void {
+        global $CFG, $DB;
+
+        $this->resetAfterTest(true);
+
+        require_once($CFG->dirroot . '/ai/provider/datacurso/db/upgrade.php');
+
+        $dbman = $DB->get_manager();
+        $legacytable = new \xmldb_table('aiprovider_datacurso_rl');
+        if ($dbman->table_exists($legacytable)) {
+            $dbman->drop_table($legacytable);
+        }
+
+        $this->create_legacy_ratelimit_table($legacytable);
+        $this->assertTrue($dbman->table_exists($legacytable));
+
+        \xmldb_aiprovider_datacurso_upgrade(2026042900);
+
+        $this->assertFalse($dbman->table_exists($legacytable));
+    }
+
+    /**
+     * Create legacy ratelimit table used before rename.
+     *
+     * @param \xmldb_table $table
+     * @return void
+     */
+    private function create_legacy_ratelimit_table(\xmldb_table $table): void {
+        global $DB;
+
+        $dbman = $DB->get_manager();
+
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('serviceid', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, '');
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+        $dbman->create_table($table);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'aiprovider_datacurso';
-$plugin->release = '1.1.5';
-$plugin->version = 2026042900;
+$plugin->release = '1.1.6';
+$plugin->version = 2026042901;
 $plugin->requires = 2024100700;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [405, 405];


### PR DESCRIPTION
### Context
Moodle Performance overview -> Database schema check reports `aiprovider_datacurso_rl table is not expected` on upgraded sites that still keep the legacy ratelimit table.

### Description
- Add a new upgrade step that drops legacy table `aiprovider_datacurso_rl` when present.
- Bump plugin metadata to trigger the upgrade step (`release 1.1.6`, `version 2026042901`).
- Add a regression upgrade test that creates the legacy table and asserts it is removed by upgrade.
- Document the fix in `CHANGES.md`.

### Steps to review
1. Update the plugin to this branch from `MOODLE_405_STABLE`.
2. Run the plugin upgrade path from a site state that still contains `aiprovider_datacurso_rl`.
3. Open Performance overview -> Database schema check and confirm the unexpected-table warning is gone.

### Verification
The upgrade path now cleans up the obsolete table and keeps the live schema aligned with `install.xml`, preventing the schema check warning.

### License
By submitting this pull request, I confirm that my contribution is made under the terms of the project license.